### PR TITLE
Pass example instance to before/after callbacks

### DIFF
--- a/lib/Test/Spec/Example.pm
+++ b/lib/Test/Spec/Example.pm
@@ -126,14 +126,14 @@ sub _runner {
   #
   return $ctx->contextualize(sub {
     $ctx->_run_before_all_once;
-    $ctx->_run_before('each');
+    $ctx->_run_before('each', $self);
     if ( @remainder ) {
       $self->_runner(@remainder);
     }
     else {
       $ctx->_in_anonymous_context($self->code, $self);
     }
-    $ctx->_run_after('each');
+    $ctx->_run_after('each', $self);
     # "after 'all'" only happens during context destruction (DEMOLISH).
     # This is the only way I can think to make this work right
     # in the case that only specific test methods are run.

--- a/t/example_in_handler.t
+++ b/t/example_in_handler.t
@@ -3,6 +3,18 @@ package Testcase::Spec::ExampleInHandler;
 use Test::Spec;
 
 describe "Test::Spec" => sub {
+  before sub {
+    my ($example) = @_;
+    ok($example);
+    isa_ok($example, 'Test::Spec::Example');
+  };
+
+  after sub {
+    my ($example) = @_;
+    ok($example);
+    isa_ok($example, 'Test::Spec::Example');
+  };
+
   it "should pass an example instance" => sub {
     my ($example) = @_;
     ok($example);


### PR DESCRIPTION
This PR makes example instance being passed into before/after callback.

This is useful when you are doing contextual fixtures or mocks.

For example:
```perl

before sub {
    my ($example) = @_;
   
    Test::Fixtures->load_fixtures($example->name);
}

it 'do something super evil' => sub {
 ...
};
```